### PR TITLE
fix: correct undefined variable in GeoBR.comparableareas error message

### DIFF
--- a/src/geobr.jl
+++ b/src/geobr.jl
@@ -442,7 +442,7 @@ function comparableareas(; startyear=1970, endyear=2010, version=v"1.7.0", kwarg
   years = (1872, 1900, 1911, 1920, 1933, 1940, 1950, 1960, 1970, 1980, 1991, 2000, 2010)
 
   if startyear ∉ years || endyear ∉ years
-    throw(ArgumentError("invalid `startyear` or `endyear`, please use one these: $years_available"))
+    throw(ArgumentError("invalid `startyear` or `endyear`, please use one these: $years"))
   end
 
   table = metadata(; version)


### PR DESCRIPTION
## Bug Fix

`GeoBR.comparableareas()` throws `UndefVarError` instead of the intended `ArgumentError` when given invalid year parameters.

### Root Cause

Line 445 of `src/geobr.jl` references a non-existent variable `years_available`:

```julia
throw(ArgumentError("invalid \`startyear\` or \`endyear\`, please use one these: \$years_available"))
```

The actual variable is `years` (defined on line 442):

```julia
years = (1872, 1900, 1911, 1920, 1933, 1940, 1950, 1960, 1970, 1980, 1991, 2000, 2010)
```

### Before
```
UndefVarError: years_available not defined
```

### After
```
ArgumentError: invalid \`startyear\` or \`endyear\`, please use one these: (1872, 1900, 1911, 1920, 1933, 1940, 1950, 1960, 1970, 1980, 1991, 2000, 2010)
```