### PR TITLE
Add coverage for argument validation paths

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,9 +12,17 @@ using Test
 
     gtb = GADM.get("ISR", depth=1)
     @test length(gtb.geometry) == 7
+
+    @test_throws ArgumentError GADM.download("XYZ")
+    @test_throws ArgumentError GADM.download("SVN"; version=v"9.9")
   end
 
   @testset "NaturalEarth" begin
+    @test_throws ArgumentError NaturalEarth.download("1:1", "Admin 0 - Countries", "countries")
+    @test_throws ArgumentError NaturalEarth.countries("missing")
+    @test_throws ArgumentError NaturalEarth.borders("missing")
+    @test_throws ArgumentError NaturalEarth.states("missing")
+
     gtb = NaturalEarth.countries()
     @test gtb.geometry isa GeometrySet
     @test paramdim(gtb.geometry) == 2
@@ -223,6 +231,8 @@ using Test
   end
 
   @testset "GeoBR" begin
+    @test_throws ArgumentError GeoBR.download("metadata_1.7.0_gpkg.csv"; version=v"9.9.9")
+
     gtb = GeoBR.state()
     @test gtb.geometry isa GeometrySet
     @test paramdim(gtb.geometry) == 2


### PR DESCRIPTION
# Add coverage for argument validation paths

Closes #40.

## Summary

- Add tests for invalid GADM country codes and API versions.
- Add tests for invalid NaturalEarth scales and variants.
- Add a test for invalid GeoBR API versions.

## Verification

```sh
julia --project=. -e 'using Pkg; Pkg.test(; coverage=true)'
```

Result: `144/144` tests passed in `1m20.5s`.

Coverage hit lines increased from `251/503` to `299/503` across the package source `.cov` files:

- `src/gadm.jl`: `26/36` to `28/36`
- `src/geobr.jl`: `33/37` to `34/37`
- `src/naturalearth.jl`: `190/428` to `235/428`
